### PR TITLE
#3 prevent duplicate binding return types on one module

### DIFF
--- a/src/cli/utils/scanner/process-bindings/__fixtures__/test-modules-dupe-binding.ts
+++ b/src/cli/utils/scanner/process-bindings/__fixtures__/test-modules-dupe-binding.ts
@@ -1,0 +1,23 @@
+import { dip } from '../../../../../lib/index';
+
+export interface IFace {
+  hello(): string;
+}
+
+export class Impl0 implements IFace {
+  hello(): string {
+    return 'world_0';
+  }
+}
+
+export class Impl1 implements IFace {
+  hello(): string {
+    return 'world_1';
+  }
+}
+
+// Type with duplicate interface types - should cause error
+export type DuplicateInterfaceBindings = {
+  testService1: dip.Bind.Reusable<Impl0, IFace>;
+  testService2: dip.Bind.Transient<Impl1, IFace>;
+};

--- a/src/cli/utils/scanner/process-bindings/__fixtures__/test-modules.ts
+++ b/src/cli/utils/scanner/process-bindings/__fixtures__/test-modules.ts
@@ -50,3 +50,9 @@ export type MultiBindings = {
   logger: dip.Bind.Transient<Logger, ILogger>;
   config: dip.Bind.Static<ITestService>;
 };
+
+// Type with duplicate interface types - should cause error
+export type DuplicateInterfaceBindings = {
+  testService1: dip.Bind.Reusable<TestService, ITestService>;
+  testService2: dip.Bind.Transient<TestService, ITestService>;
+};


### PR DESCRIPTION
## Description

resolves #3 

At code-generation time, throws an error if a module declares two bindings that return the same type.

> 💡 **New to contributing?** Check out our [CONTRIBUTORS.md](../CONTRIBUTORS.md) guide for setup instructions and development workflow.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

